### PR TITLE
random is no longer part of scipy

### DIFF
--- a/ffnet/ffnet.py
+++ b/ffnet/ffnet.py
@@ -13,7 +13,8 @@ Main ffnet class and utility functions
 """
 
 from ._version import version
-from scipy import zeros, ones, random, optimize, sqrt, ndarray, array
+from scipy import zeros, ones, optimize, sqrt, ndarray, array
+from numpy import random
 import networkx as NX
 from .fortran import _ffnet as netprop
 from .pikaia import pikaia


### PR DESCRIPTION
scipy no longer has a random import. You need to use numpy.

Note that despite what this says in the scipy code:
```python
 _msg = ('scipy.{0} is deprecated and will be removed in SciPy 2.0.0, '
     |   'use numpy.random.{0} instead')
```
it looks like even scipy 1.11.1 doesn't have it:

```
$ ipython3
Python 3.10.12 | packaged by conda-forge | (main, Jun 23 2023, 22:40:32) [GCC 12.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import scipy

In [2]: scipy.__version__
Out[2]: '1.11.1'

In [3]: from scipy import random
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[3], line 1
----> 1 from scipy import random

ImportError: cannot import name 'random' from 'scipy' (/discover/nobackup/mathomp4/Miniconda-Test/python3/23.3.1-0_py3.10/2023-07-11/lib/python3.10/site-packages/scipy/__init__.py)
```