### PR TITLE
Update references to README.rst to README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE.txt README.rst
+include LICENSE.txt README.md
 # include examples/*.py examples/data/*.dat

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         name              = 'ffnet',
         version           = '0.8.6',
         description       = 'Feed-forward neural network solution for python',
-        long_description  = open('README.rst', 'r').read(),
+        long_description  = open('README.md', 'r').read(),
         keywords          = ['neural networks'],
         author            = 'Marek Wojciechowski',
         author_email      = 'mwojc@p.lodz.pl',


### PR DESCRIPTION
In trying to install ffnet from `master` here today I got hit with:
```
Collecting git+https://github.com/mrkwjc/ffnet
  Cloning https://github.com/mrkwjc/ffnet to ./tmp-for-ffnet/pip-req-build-d4yhl63a
  Running command git clone --filter=blob:none --quiet https://github.com/mrkwjc/ffnet /gpfsm/dswdev/mathomp4/GEOSpyD/tmp-for-ffnet/pip-req-build-d4yhl63a
  Resolved https://github.com/mrkwjc/ffnet to commit a0fd03bb2771b978c414abd6dc04857740f25789
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/gpfsm/dswdev/mathomp4/GEOSpyD/tmp-for-ffnet/pip-req-build-d4yhl63a/setup.py", line 69, in <module>
          long_description  = open('README.rst', 'r').read(),
                              ^^^^^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: 'README.rst'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

The fix seems simple enough as `README.rst` is now `README.md`, so I changed the two `README.rst` mentions I saw in the code to `README.md`